### PR TITLE
add slug query to posts and username query to users

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,8 @@ module.exports = {
     "browser": true,
     "commonjs": true,
     "node": true,
-    "jest": true
+    "jest": true,
+    "es6": true
     // "es2021": true
   },
   "extends": "eslint:recommended",

--- a/app/client/src/components/MainPostItem/MainPostItem.jsx
+++ b/app/client/src/components/MainPostItem/MainPostItem.jsx
@@ -54,7 +54,7 @@ const MainPostItem = ({ obj, setPosts, posts }) => {
   };
 
   const navigateToSpecHandler = () => {
-    navigate(`/posts/${obj.id}`);
+    navigate(`/posts/${obj.slug}`);
   };
 
   const navigateToEditHandler = () => {
@@ -62,7 +62,7 @@ const MainPostItem = ({ obj, setPosts, posts }) => {
   };
 
   const takeToUserProfHandler = () => {
-    navigate(`/users/${obj.User.id}`);
+    navigate(`/users/${obj.User.username}`);
   };
 
   const isUpvoted = () => {

--- a/app/server/controllers/posts_controller.js
+++ b/app/server/controllers/posts_controller.js
@@ -7,6 +7,8 @@ const createPost = async (req, res) => {
   }
 
   const post = Post.build({ ...postParams(req), UserId: currentUserId(req) });
+  await post.slugfy();
+
   await post.save()
     .then((data) => {
       res.status(200).send(data.getData());
@@ -119,7 +121,13 @@ const upvotePost = async (req, res) => {
 // helpers ///////////////////////////////////////////
 
 const setPost = async (params) => {
-  const post = await Post.findByPk(params.id, Post.fullScope(User, Upvote));
+
+  let post = await Post.findByPk(params.id, Post.fullScope(User, Upvote))
+    .catch(() => {});
+  if (!post) {
+    post = await Post.findOne({where: {slug: params.id}});
+  }
+
   return post;
 };
 

--- a/app/server/controllers/users_controller.js
+++ b/app/server/controllers/users_controller.js
@@ -84,7 +84,7 @@ const getUser = async (req, res) => {
     return;
   }
 
-  const user = await User.findByPk(req.params.id);
+  const user = await User.findOne({where: {username: req.params.username}});
 
   if (user === null) {
     res.status(404).send({ error: "this user doest exist" });

--- a/app/server/routes/users_route.js
+++ b/app/server/routes/users_route.js
@@ -7,6 +7,6 @@ router.get("/api/logged_user", loggedUser);
 router.post("/api/sign_up", signUp);
 router.patch("/api/logged_user", updateUser);
 
-router.get("/api/users/:id", getUser);
+router.get("/api/users/:username", getUser);
 
 module.exports = router;

--- a/db/migrations/20220820002903-add_slug_to_posts.js
+++ b/db/migrations/20220820002903-add_slug_to_posts.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    return [
+      queryInterface.addColumn(
+        'Posts',
+        'slug',
+        {
+          type: Sequelize.STRING,
+          unique: true,
+          allowNull: true,
+        }
+      ),
+    ]
+  },
+
+  async down (queryInterface, Sequelize) {
+    return [
+      queryInterface.removeColumn('Posts', 'slug')
+    ]
+  }
+};

--- a/db/seeders/20220818182804-test_posts.js
+++ b/db/seeders/20220818182804-test_posts.js
@@ -19,6 +19,7 @@ module.exports = {
 
     const posts = []
 
+    let index = 0
     users.forEach((userId) => {
       Array.apply(null, Array(10)).forEach(() => {
         const place = countries[Math.floor(Math.random() * countries.length)]
@@ -26,9 +27,11 @@ module.exports = {
           title: `amazing travel to ${place}`,
           content: `really cool travel to ${place} 10/10 i really recommend`,
           UserId: userId,
+          slug: `amazing-travel-to-${place.replace(" ", "-")}-${index}`,
           ...defaultValues()
         }
         posts.push(post)
+        index += 1
       })
     })
 

--- a/test/controllers/posts.test.js
+++ b/test/controllers/posts.test.js
@@ -239,6 +239,20 @@ describe("posts controller", () => {
       });
   });
 
+
+  jest.retryTimes(10);
+  test("get /api/posts/:slug should return post", async () => {
+    await this.post.save();
+
+    await request(app)
+      .get(`/api/posts/${this.post.slug}`)
+      .expect(200)
+      .expect("Content-type", /json/)
+      .then(async (serverRes) => {
+        expect(serverRes.body).toEqual(expect.any(Object));
+      });
+  });
+
   jest.retryTimes(10);
   test("get /api/posts/:id should return post if logged", async () => {
     await this.post.save();
@@ -271,8 +285,12 @@ describe("posts controller", () => {
 
   jest.retryTimes(10);
   test("get /api/posts should list posts ordered by creation date", async () => {
-    const post1 = await Post.create({ ...postMock, UserId: this.postUser.id });
-    const post2 = await Post.create({ ...postMock, UserId: this.postUser.id });
+    const post1 = await Post.build({ ...postMock, UserId: this.postUser.id });
+    await post1.slugfy();
+    await post1.save();
+    const post2 = await Post.build({ ...postMock, UserId: this.postUser.id });
+    await post2.slugfy();
+    await post2.save();
 
     await request(app)
       .get("/api/posts")

--- a/test/controllers/users.test.js
+++ b/test/controllers/users.test.js
@@ -159,11 +159,11 @@ describe("users controller", () => {
       });
   });
 
-  test("get /api/users/:id should return the specific user", async () => {
+  test("get /api/users/:username should return the specific user", async () => {
     const authenticatedSession = await logUser(this.user, app);
 
     await authenticatedSession
-      .get(`/api/users/${this.user.id}`)
+      .get(`/api/users/${this.user.username}`)
       .expect(200)
       .expect("Content-type", /json/)
       .then(async (serverRes) => {
@@ -171,7 +171,7 @@ describe("users controller", () => {
       });
   });
 
-  test("get /api/users/:id should return 404 the specific user doest exist", async () => {
+  test("get /api/users/:username should return 404 the specific user doest exist", async () => {
     const authenticatedSession = await logUser(this.user, app);
 
     await authenticatedSession
@@ -183,7 +183,7 @@ describe("users controller", () => {
       });
   });
 
-  test("get /api/users/:id should return 401 if not logged", async () => {
+  test("get /api/users/:username should return 401 if not logged", async () => {
     await this.user.save();
 
     await request(app)

--- a/test/mocks/post.js
+++ b/test/mocks/post.js
@@ -1,6 +1,7 @@
 const post = {
   title: "post title",
-  content: "post content"
+  content: "post content",
+  slug: "post-title"
 };
 
 module.exports = post;


### PR DESCRIPTION
add slug column to posts and ensure they are uniq
also auto generate a slug when creating a post using the title
make /api/posts/:id accept a slug in addition to the id
update the seeds to have slugs
change 2 lines in the client to navigate to the user profile using username and post using slug