### PR TITLE
fix undefined slug when using Post.ranked

### DIFF
--- a/app/server/models/post.js
+++ b/app/server/models/post.js
@@ -28,6 +28,7 @@ module.exports = (sequelize, DataTypes) => {
           "id",
           "UserId",
           "title",
+          "slug",
           "content",
           "upvotesCount",
           "createdAt",


### PR DESCRIPTION
when i added the posts ranking i forgot to return the slug in the ranked ranked scope, this commit fixes it by adding slug in the post ranked scope.